### PR TITLE
Request to Merge

### DIFF
--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperator.java
@@ -18,6 +18,7 @@
 
 package org.apache.flink.streaming.api.connector.sink2;
 
+import org.apache.flink.annotation.Internal;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
 import org.apache.flink.api.common.typeutils.base.array.BytePrimitiveArraySerializer;
@@ -29,7 +30,6 @@ import org.apache.flink.runtime.state.StateInitializationContext;
 import org.apache.flink.runtime.state.StateSnapshotContext;
 import org.apache.flink.streaming.api.graph.StreamConfig;
 import org.apache.flink.streaming.api.operators.AbstractStreamOperator;
-import org.apache.flink.streaming.api.operators.BoundedOneInput;
 import org.apache.flink.streaming.api.operators.OneInputStreamOperator;
 import org.apache.flink.streaming.api.operators.Output;
 import org.apache.flink.streaming.api.operators.util.SimpleVersionedListState;
@@ -47,10 +47,53 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import static org.apache.flink.streaming.api.connector.sink2.CommittableMessage.EOI;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
-class GlobalCommitterOperator<CommT, GlobalCommT> extends AbstractStreamOperator<Void>
-        implements OneInputStreamOperator<CommittableMessage<CommT>, Void>, BoundedOneInput {
+/**
+ * Implements the {@code GlobalCommitter}.
+ *
+ * <p>This operator usually trails behind a {@code CommitterOperator}. In this case, the global
+ * committer will receive committables from the committer operator through {@link
+ * #processElement(StreamRecord)}. Once all committables from all subtasks have been received, the
+ * global committer will commit them. This approach also works for any number of intermediate custom
+ * operators between the committer and the global committer in a custom post-commit topology.
+ *
+ * <p>That means that the global committer will not wait for {@link
+ * #notifyCheckpointComplete(long)}. In many cases, it receives the callback before the actual
+ * committables anyway. So it would effectively globally commit one checkpoint later.
+ *
+ * <p>However, we can leverage the following observation: the global committer will only receive
+ * committables iff the respective checkpoint was completed and upstream committers received the
+ * {@link #notifyCheckpointComplete(long)}. So by waiting for all committables of a given
+ * checkpoint, we implicitly know that the checkpoint was successful and the global committer is
+ * supposed to globally commit.
+ *
+ * <p>Note that committables of checkpoint X are not checkpointed in X because the global committer
+ * is trailing behind the checkpoint. They are replayed from the committer state in case of an
+ * error. The state only includes incomplete checkpoints coming from upstream committers not
+ * receiving {@link #notifyCheckpointComplete(long)}. All committables received are successful.
+ *
+ * <p>In rare cases, the GlobalCommitterOperator may not be connected (in)directly to a committer
+ * but instead is connected (in)directly to a writer. In this case, the global committer needs to
+ * perform the 2PC protocol instead of the committer. Thus, we absolutely need to use {@link
+ * #notifyCheckpointComplete(long)} similarly to the {@code CommitterOperator}. Hence, {@link
+ * #commitOnInput} is set to false in this case. In particular, the following three prerequisites
+ * must be met:
+ *
+ * <ul>
+ *   <li>No committer is upstream of which we could implicitly infer {@link
+ *       #notifyCheckpointComplete(long)} as sketched above.
+ *   <li>The application runs in streaming mode.
+ *   <li>Checkpointing is enabled.
+ * </ul>
+ *
+ * <p>In all other cases (batch or upstream committer or checkpointing is disabled), the global
+ * committer commits on input.
+ */
+@Internal
+public class GlobalCommitterOperator<CommT, GlobalCommT> extends AbstractStreamOperator<Void>
+        implements OneInputStreamOperator<CommittableMessage<CommT>, Void> {
 
     /** The operator's state descriptor. */
     private static final ListStateDescriptor<byte[]> GLOBAL_COMMITTER_OPERATOR_RAW_STATES_DESC =
@@ -60,6 +103,11 @@ class GlobalCommitterOperator<CommT, GlobalCommT> extends AbstractStreamOperator
     private final SerializableSupplier<Committer<CommT>> committerFactory;
     private final SerializableSupplier<SimpleVersionedSerializer<CommT>>
             committableSerializerFactory;
+    /**
+     * Depending on whether there is an upstream committer or it's connected to a writer, we may
+     * either wait for notifyCheckpointCompleted or not.
+     */
+    private final boolean commitOnInput;
 
     private ListState<GlobalCommittableWrapper<CommT, GlobalCommT>> globalCommitterState;
     private Committer<CommT> committer;
@@ -71,11 +119,13 @@ class GlobalCommitterOperator<CommT, GlobalCommT> extends AbstractStreamOperator
     @Nullable private SimpleVersionedSerializer<GlobalCommT> globalCommittableSerializer;
     private List<GlobalCommT> sinkV1State = new ArrayList<>();
 
-    GlobalCommitterOperator(
+    public GlobalCommitterOperator(
             SerializableSupplier<Committer<CommT>> committerFactory,
-            SerializableSupplier<SimpleVersionedSerializer<CommT>> committableSerializerFactory) {
+            SerializableSupplier<SimpleVersionedSerializer<CommT>> committableSerializerFactory,
+            boolean commitOnInput) {
         this.committerFactory = checkNotNull(committerFactory);
         this.committableSerializerFactory = checkNotNull(committableSerializerFactory);
+        this.commitOnInput = commitOnInput;
     }
 
     @Override
@@ -103,20 +153,11 @@ class GlobalCommitterOperator<CommT, GlobalCommT> extends AbstractStreamOperator
     @Override
     public void initializeState(StateInitializationContext context) throws Exception {
         super.initializeState(context);
-        final CommittableCollectorSerializer<CommT> committableCollectorSerializer =
-                new CommittableCollectorSerializer<>(
-                        committableSerializer,
-                        getRuntimeContext().getTaskInfo().getIndexOfThisSubtask(),
-                        getRuntimeContext().getTaskInfo().getMaxNumberOfParallelSubtasks(),
-                        metricGroup);
-        final SimpleVersionedSerializer<GlobalCommittableWrapper<CommT, GlobalCommT>> serializer =
-                new GlobalCommitterSerializer<>(
-                        committableCollectorSerializer, globalCommittableSerializer, metricGroup);
         globalCommitterState =
                 new SimpleVersionedListState<>(
                         context.getOperatorStateStore()
                                 .getListState(GLOBAL_COMMITTER_OPERATOR_RAW_STATES_DESC),
-                        serializer);
+                        getCommitterStateSerializer());
         if (context.isRestored()) {
             globalCommitterState
                     .get()
@@ -125,40 +166,64 @@ class GlobalCommitterOperator<CommT, GlobalCommT> extends AbstractStreamOperator
                                 sinkV1State.addAll(cc.getGlobalCommittables());
                                 committableCollector.merge(cc.getCommittableCollector());
                             });
-            lastCompletedCheckpointId = context.getRestoredCheckpointId().getAsLong();
             // try to re-commit recovered transactions as quickly as possible
-            commit(lastCompletedCheckpointId);
+            if (context.getRestoredCheckpointId().isPresent()) {
+                commit(context.getRestoredCheckpointId().getAsLong());
+            }
         }
+    }
+
+    private SimpleVersionedSerializer<GlobalCommittableWrapper<CommT, GlobalCommT>>
+            getCommitterStateSerializer() {
+        final CommittableCollectorSerializer<CommT> committableCollectorSerializer =
+                new CommittableCollectorSerializer<>(
+                        committableSerializer,
+                        getRuntimeContext().getTaskInfo().getIndexOfThisSubtask(),
+                        getRuntimeContext().getTaskInfo().getMaxNumberOfParallelSubtasks(),
+                        metricGroup);
+        return new GlobalCommitterSerializer<>(
+                committableCollectorSerializer, globalCommittableSerializer, metricGroup);
     }
 
     @Override
     public void notifyCheckpointComplete(long checkpointId) throws Exception {
         super.notifyCheckpointComplete(checkpointId);
-        lastCompletedCheckpointId = Math.max(lastCompletedCheckpointId, checkpointId);
-        commit(lastCompletedCheckpointId);
+        if (!commitOnInput) {
+            commit(checkpointId);
+        }
     }
 
-    private void commit(long checkpointId) throws IOException, InterruptedException {
-        for (CheckpointCommittableManager<CommT> checkpoint :
-                committableCollector.getCheckpointCommittablesUpTo(checkpointId)) {
-            checkpoint.commit(committer);
-        }
-        committableCollector.compact();
-    }
-
-    @Override
-    public void endInput() throws Exception {
-        final CheckpointCommittableManager<CommT> endOfInputCommittable =
-                committableCollector.getEndOfInputCommittable();
-        if (endOfInputCommittable != null) {
-            do {
-                endOfInputCommittable.commit(committer);
-            } while (!committableCollector.isFinished());
-        }
+    private void commit(long checkpointIdOrEOI) throws IOException, InterruptedException {
+        lastCompletedCheckpointId = Math.max(lastCompletedCheckpointId, checkpointIdOrEOI);
+        // this is true for the last commit and we need to make sure that all committables are
+        // indeed committed as this function will never be invoked again
+        boolean waitForAllCommitted =
+                lastCompletedCheckpointId == EOI
+                        && committableCollector
+                                .getEndOfInputCommittable()
+                                .map(CheckpointCommittableManager::hasGloballyReceivedAll)
+                                .orElse(false);
+        do {
+            for (CheckpointCommittableManager<CommT> committable :
+                    committableCollector.getCheckpointCommittablesUpTo(lastCompletedCheckpointId)) {
+                if (committable.hasGloballyReceivedAll()) {
+                    committable.commit(committer);
+                }
+            }
+            committableCollector.compact();
+        } while (waitForAllCommitted && !committableCollector.isFinished());
     }
 
     @Override
     public void processElement(StreamRecord<CommittableMessage<CommT>> element) throws Exception {
         committableCollector.addMessage(element.getValue());
+
+        // commitOnInput implies that the global committer is not using notifyCheckpointComplete.
+        // Instead, it commits as soon as it receives all committables of a specific checkpoint.
+        // For commitOnInput=false, lastCompletedCheckpointId is only updated on
+        // notifyCheckpointComplete.
+        if (commitOnInput) {
+            commit(element.getValue().getCheckpointIdOrEOI());
+        }
     }
 }

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java
@@ -50,6 +50,7 @@ import org.apache.flink.streaming.api.transformations.BroadcastStateTransformati
 import org.apache.flink.streaming.api.transformations.CacheTransformation;
 import org.apache.flink.streaming.api.transformations.CoFeedbackTransformation;
 import org.apache.flink.streaming.api.transformations.FeedbackTransformation;
+import org.apache.flink.streaming.api.transformations.GlobalCommitterTransform;
 import org.apache.flink.streaming.api.transformations.KeyedBroadcastStateTransformation;
 import org.apache.flink.streaming.api.transformations.KeyedMultipleInputTransformation;
 import org.apache.flink.streaming.api.transformations.LegacySinkTransformation;
@@ -69,6 +70,7 @@ import org.apache.flink.streaming.api.transformations.UnionTransformation;
 import org.apache.flink.streaming.api.transformations.WithBoundedness;
 import org.apache.flink.streaming.runtime.translators.BroadcastStateTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.CacheTransformationTranslator;
+import org.apache.flink.streaming.runtime.translators.GlobalCommitterTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.KeyedBroadcastStateTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.LegacySinkTransformationTranslator;
 import org.apache.flink.streaming.runtime.translators.LegacySourceTransformationTranslator;
@@ -172,6 +174,7 @@ public class StreamGraphGenerator {
         tmp.put(KeyedMultipleInputTransformation.class, new MultiInputTransformationTranslator<>());
         tmp.put(SourceTransformation.class, new SourceTransformationTranslator<>());
         tmp.put(SinkTransformation.class, new SinkTransformationTranslator<>());
+        tmp.put(GlobalCommitterTransform.class, new GlobalCommitterTransformationTranslator<>());
         tmp.put(LegacySinkTransformation.class, new LegacySinkTransformationTranslator<>());
         tmp.put(LegacySourceTransformation.class, new LegacySourceTransformationTranslator<>());
         tmp.put(UnionTransformation.class, new UnionTransformationTranslator<>());

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/api/transformations/GlobalCommitterTransform.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/api/transformations/GlobalCommitterTransform.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.api.transformations;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.connector.sink2.Committer;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.core.io.SimpleVersionedSerializer;
+import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.StandardSinkTopologies;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.util.function.SerializableSupplier;
+
+import org.apache.flink.shaded.guava32.com.google.common.collect.Lists;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Transformation for global committer. Only used to fetch if the pipeline is streaming or batch
+ * with the respective {@link
+ * org.apache.flink.streaming.runtime.translators.GlobalCommitterTransformationTranslator}.
+ *
+ * @param <CommT>
+ */
+@Internal
+public class GlobalCommitterTransform<CommT> extends TransformationWithLineage<Void> {
+
+    private final DataStream<CommittableMessage<CommT>> inputStream;
+    private final SerializableSupplier<Committer<CommT>> committerFactory;
+    private final SerializableSupplier<SimpleVersionedSerializer<CommT>> committableSerializer;
+
+    public GlobalCommitterTransform(
+            DataStream<CommittableMessage<CommT>> inputStream,
+            SerializableSupplier<Committer<CommT>> committerFactory,
+            SerializableSupplier<SimpleVersionedSerializer<CommT>> committableSerializer) {
+        super(StandardSinkTopologies.GLOBAL_COMMITTER_TRANSFORMATION_NAME, Types.VOID, 1, true);
+        this.inputStream = inputStream;
+        this.committerFactory = committerFactory;
+        this.committableSerializer = committableSerializer;
+    }
+
+    @Override
+    public void setChainingStrategy(ChainingStrategy strategy) {}
+
+    @Override
+    protected List<Transformation<?>> getTransitivePredecessorsInternal() {
+        final List<Transformation<?>> result = Lists.newArrayList();
+        result.add(this);
+        result.addAll(inputStream.getTransformation().getTransitivePredecessors());
+        return result;
+    }
+
+    @Override
+    public List<Transformation<?>> getInputs() {
+        return Collections.singletonList(inputStream.getTransformation());
+    }
+
+    public DataStream<CommittableMessage<CommT>> getInputStream() {
+        return inputStream;
+    }
+
+    public SerializableSupplier<Committer<CommT>> getCommitterFactory() {
+        return committerFactory;
+    }
+
+    public SerializableSupplier<SimpleVersionedSerializer<CommT>> getCommittableSerializer() {
+        return committableSerializer;
+    }
+}

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManager.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManager.java
@@ -56,14 +56,20 @@ public interface CheckpointCommittableManager<CommT> {
      */
     CommittableSummary<CommT> getSummary(int emittingSubtaskId, int emittingNumberOfSubtasks);
 
+    boolean isFinished();
+
+    /**
+     * Returns true if all committables of all upstream subtasks arrived, which is only guaranteed
+     * to happen if the DOP of the caller is 1.
+     */
+    boolean hasGloballyReceivedAll();
+
     /**
      * Commits all due committables if all respective committables of the specific subtask and
      * checkpoint have been received.
      *
      * @param committer used to commit to the external system
      * @return successfully committed committables with meta information
-     * @throws IOException
-     * @throws InterruptedException
      */
     Collection<CommittableWithLineage<CommT>> commit(Committer<CommT> committer)
             throws IOException, InterruptedException;

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManagerImpl.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManagerImpl.java
@@ -143,9 +143,17 @@ class CheckpointCommittableManagerImpl<CommT> implements CheckpointCommittableMa
                         .sum());
     }
 
-    boolean isFinished() {
+    @Override
+    public boolean isFinished() {
         return subtasksCommittableManagers.values().stream()
                 .allMatch(SubtaskCommittableManager::isFinished);
+    }
+
+    @Override
+    public boolean hasGloballyReceivedAll() {
+        return subtasksCommittableManagers.size() == numberOfSubtasks
+                && subtasksCommittableManagers.values().stream()
+                        .allMatch(SubtaskCommittableManager::hasReceivedAll);
     }
 
     @Override

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollector.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollector.java
@@ -26,14 +26,13 @@ import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
 import org.apache.flink.streaming.api.connector.sink2.CommittableSummary;
 import org.apache.flink.streaming.api.connector.sink2.CommittableWithLineage;
 
-import javax.annotation.Nullable;
-
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.NavigableMap;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
@@ -141,9 +140,8 @@ public class CommittableCollector<CommT> {
      *
      * @return {@link CheckpointCommittableManager}
      */
-    @Nullable
-    public CheckpointCommittableManager<CommT> getEndOfInputCommittable() {
-        return checkpointCommittables.get(EOI);
+    public Optional<CheckpointCommittableManager<CommT>> getEndOfInputCommittable() {
+        return Optional.ofNullable(checkpointCommittables.get(EOI));
     }
 
     /**

--- a/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/translators/GlobalCommitterTransformationTranslator.java
+++ b/flink-runtime/src/main/java/org/apache/flink/streaming/runtime/translators/GlobalCommitterTransformationTranslator.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.streaming.runtime.translators;
+
+import org.apache.flink.annotation.Internal;
+import org.apache.flink.api.common.typeinfo.Types;
+import org.apache.flink.api.dag.Transformation;
+import org.apache.flink.streaming.api.connector.sink2.CommittableMessage;
+import org.apache.flink.streaming.api.connector.sink2.GlobalCommitterOperator;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.graph.TransformationTranslator;
+import org.apache.flink.streaming.api.operators.ChainingStrategy;
+import org.apache.flink.streaming.api.operators.StreamOperatorFactory;
+import org.apache.flink.streaming.api.transformations.GlobalCommitterTransform;
+import org.apache.flink.streaming.api.transformations.OneInputTransformation;
+import org.apache.flink.streaming.api.transformations.PhysicalTransformation;
+import org.apache.flink.streaming.runtime.operators.sink.CommitterOperatorFactory;
+import org.apache.flink.streaming.runtime.operators.sink.SinkWriterOperatorFactory;
+
+import java.util.ArrayDeque;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Queue;
+import java.util.Set;
+
+import static org.apache.flink.streaming.api.connector.sink2.StandardSinkTopologies.GLOBAL_COMMITTER_TRANSFORMATION_NAME;
+
+/**
+ * A {@link TransformationTranslator} for the {@link GlobalCommitterOperator}. The main purpose is
+ * to detect whether we set {@link GlobalCommitterOperator#commitOnInput} or not.
+ */
+@Internal
+public class GlobalCommitterTransformationTranslator<CommT>
+        implements TransformationTranslator<Void, GlobalCommitterTransform<CommT>> {
+
+    @Override
+    public Collection<Integer> translateForBatch(
+            GlobalCommitterTransform<CommT> transformation, Context context) {
+        return translateInternal(transformation, true);
+    }
+
+    @Override
+    public Collection<Integer> translateForStreaming(
+            GlobalCommitterTransform<CommT> transformation, Context context) {
+        return translateInternal(transformation, false);
+    }
+
+    private Collection<Integer> translateInternal(
+            GlobalCommitterTransform<CommT> globalCommitterTransform, boolean batch) {
+        DataStream<CommittableMessage<CommT>> inputStream =
+                globalCommitterTransform.getInputStream();
+        boolean checkpointingEnabled =
+                inputStream
+                        .getExecutionEnvironment()
+                        .getCheckpointConfig()
+                        .isCheckpointingEnabled();
+        boolean commitOnInput = batch || !checkpointingEnabled || hasUpstreamCommitter(inputStream);
+
+        // Create a global shuffle and add the global committer with parallelism 1.
+        final PhysicalTransformation<Void> transformation =
+                (PhysicalTransformation<Void>)
+                        inputStream
+                                .global()
+                                .transform(
+                                        GLOBAL_COMMITTER_TRANSFORMATION_NAME,
+                                        Types.VOID,
+                                        new GlobalCommitterOperator<>(
+                                                globalCommitterTransform.getCommitterFactory(),
+                                                globalCommitterTransform.getCommittableSerializer(),
+                                                commitOnInput))
+                                .getTransformation();
+        transformation.setChainingStrategy(ChainingStrategy.ALWAYS);
+        transformation.setName(GLOBAL_COMMITTER_TRANSFORMATION_NAME);
+        transformation.setParallelism(1);
+        transformation.setMaxParallelism(1);
+        return Collections.emptyList();
+    }
+
+    /**
+     * Looks for a committer in the pipeline and aborts on writer. The GlobalCommitter behaves
+     * differently if there is a committer after the writer.
+     */
+    private static boolean hasUpstreamCommitter(DataStream<?> ds) {
+        Transformation<?> dsTransformation = ds.getTransformation();
+
+        Set<Integer> seenIds = new HashSet<>();
+        Queue<Transformation<?>> pendingsTransformations =
+                new ArrayDeque<>(Collections.singleton(dsTransformation));
+        while (!pendingsTransformations.isEmpty()) {
+            Transformation<?> transformation = pendingsTransformations.poll();
+            if (transformation instanceof OneInputTransformation) {
+                StreamOperatorFactory<?> operatorFactory =
+                        ((OneInputTransformation<?, ?>) transformation).getOperatorFactory();
+                if (operatorFactory instanceof CommitterOperatorFactory) {
+                    return true;
+                }
+                if (operatorFactory instanceof SinkWriterOperatorFactory) {
+                    // don't look at the inputs of the writer
+                    continue;
+                }
+            }
+            for (Transformation<?> input : transformation.getInputs()) {
+                if (seenIds.add(input.getId())) {
+                    pendingsTransformations.add(input);
+                }
+            }
+        }
+
+        return false;
+    }
+}

--- a/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorTest.java
+++ b/flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorTest.java
@@ -25,6 +25,8 @@ import org.apache.flink.streaming.api.connector.sink2.SinkV2Assertions;
 
 import org.junit.jupiter.api.Test;
 
+import java.util.Optional;
+
 import static org.apache.flink.streaming.api.connector.sink2.CommittableMessage.EOI;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -44,7 +46,7 @@ class CommittableCollectorTest {
 
         assertThat(committableCollector.getCheckpointCommittablesUpTo(2)).hasSize(2);
 
-        assertThat(committableCollector.getEndOfInputCommittable()).isNull();
+        assertThat(committableCollector.getEndOfInputCommittable()).isNotPresent();
     }
 
     @Test
@@ -54,9 +56,10 @@ class CommittableCollectorTest {
         CommittableSummary<Integer> first = new CommittableSummary<>(1, 1, EOI, 1, 0, 0);
         committableCollector.addMessage(first);
 
-        CheckpointCommittableManager<Integer> endOfInputCommittable =
+        Optional<CheckpointCommittableManager<Integer>> endOfInputCommittable =
                 committableCollector.getEndOfInputCommittable();
-        assertThat(endOfInputCommittable).isNotNull();
-        SinkV2Assertions.assertThat(endOfInputCommittable.getSummary(1, 1)).hasCheckpointId(EOI);
+        assertThat(endOfInputCommittable).isPresent();
+        SinkV2Assertions.assertThat(endOfInputCommittable.get().getSummary(1, 1))
+                .hasCheckpointId(EOI);
     }
 }


### PR DESCRIPTION
### **PR Type**
enhancement, tests


___

### **Description**
- Enhanced `GlobalCommitterOperator` to optimize commit logic by introducing a `commitOnInput` flag.
- Refactored `StandardSinkTopologies` to utilize `GlobalCommitterTransform`.
- Added `GlobalCommitterTransformationTranslator` to handle transformation logic.
- Introduced `GlobalCommitterTransform` class for better transformation handling.
- Updated `CheckpointCommittableManager` and its implementation with new methods for state checking.
- Modified `CommittableCollector` to use `Optional` for better null safety.
- Extended test coverage with parameterized tests for `GlobalCommitterOperator`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>GlobalCommitterOperator.java</strong><dd><code>Enhance GlobalCommitterOperator with commitOnInput logic</code>&nbsp; </dd></summary>
<hr>

flink-runtime/src/main/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperator.java

<li>Added detailed documentation for <code>GlobalCommitterOperator</code>.<br> <li> Introduced <code>commitOnInput</code> flag to control commit behavior.<br> <li> Refactored state initialization and commit logic.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/flink/pull/1/files#diff-bd87c4560f78ab8086de034c7e8667ad6f15107f0855cd4efc5d36298ba1abef">+100/-35</a></td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>StandardSinkTopologies.java</strong><dd><code>Refactor StandardSinkTopologies to use GlobalCommitterTransform</code></dd></summary>
<hr>

flink-runtime/src/main/java/org/apache/flink/streaming/api/connector/sink2/StandardSinkTopologies.java

- Replaced transformation logic with `GlobalCommitterTransform`.



</details>


  </td>
  <td><a href="https://github.com/maorethians/flink/pull/1/files#diff-79b52bc40f0e0a70f6b6974f4f62e0abf49a42b26142d71f935254cbcdcb9796">+6/-17</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>StreamGraphGenerator.java</strong><dd><code>Integrate GlobalCommitterTransformationTranslator into </code><br><code>StreamGraphGenerator</code></dd></summary>
<hr>

flink-runtime/src/main/java/org/apache/flink/streaming/api/graph/StreamGraphGenerator.java

<li>Added <code>GlobalCommitterTransformationTranslator</code> to transformation <br>translators.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/flink/pull/1/files#diff-b76f7ae797f53dbefccc52ff390624f5da33fa4478d79410100cadd8a7e622a4">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>GlobalCommitterTransform.java</strong><dd><code>Introduce GlobalCommitterTransform class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

flink-runtime/src/main/java/org/apache/flink/streaming/api/transformations/GlobalCommitterTransform.java

<li>Introduced <code>GlobalCommitterTransform</code> class for global committer <br>transformations.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/flink/pull/1/files#diff-8e0e211b70d5ca1d554ad4497b410e0dd6990e3bf38c118c32afa28c52f0a9d4">+88/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>CheckpointCommittableManager.java</strong><dd><code>Extend CheckpointCommittableManager with new methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManager.java

- Added methods `isFinished` and `hasGloballyReceivedAll`.



</details>


  </td>
  <td><a href="https://github.com/maorethians/flink/pull/1/files#diff-470fa0820fea66afa6f4f0bbbd7c82b9efb3bf384a3ce5e315921d3567c75dd3">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>CheckpointCommittableManagerImpl.java</strong><dd><code>Implement new methods in CheckpointCommittableManagerImpl</code></dd></summary>
<hr>

flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CheckpointCommittableManagerImpl.java

- Implemented `isFinished` and `hasGloballyReceivedAll` methods.



</details>


  </td>
  <td><a href="https://github.com/maorethians/flink/pull/1/files#diff-937146d82a272530ef6c33367aecc733b32700148089e87a5cb0141d46931dd3">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>CommittableCollector.java</strong><dd><code>Update CommittableCollector to use Optional</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

flink-runtime/src/main/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollector.java

- Changed return type of `getEndOfInputCommittable` to `Optional`.



</details>


  </td>
  <td><a href="https://github.com/maorethians/flink/pull/1/files#diff-b93e8775341b0477acd8d12f364f211047b1128e861b4d2fe2e6e3a02762c186">+3/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>GlobalCommitterTransformationTranslator.java</strong><dd><code>Add GlobalCommitterTransformationTranslator class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

flink-runtime/src/main/java/org/apache/flink/streaming/runtime/translators/GlobalCommitterTransformationTranslator.java

<li>Added <code>GlobalCommitterTransformationTranslator</code> for translating global <br>committer transformations.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/flink/pull/1/files#diff-3cc9b3b5750b03dc944dfade03f9b54dcadccc400285c329fbbbbdc17ad2752e">+128/-0</a>&nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>SupportsPreCommitTopology.java</strong><dd><code>Document committable message handling in SupportsPreCommitTopology</code></dd></summary>
<hr>

flink-runtime/src/main/java/org/apache/flink/streaming/api/connector/sink2/SupportsPreCommitTopology.java

- Added detailed documentation for committable message handling.



</details>


  </td>
  <td><a href="https://github.com/maorethians/flink/pull/1/files#diff-e405a53bd401067ecdade111b8ab76590d0e43391e4ec259bd7d7659ca69a2ce">+13/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>GlobalCommitterOperatorTest.java</strong><dd><code>Extend GlobalCommitterOperatorTest with parameterized tests</code></dd></summary>
<hr>

flink-runtime/src/test/java/org/apache/flink/streaming/api/connector/sink2/GlobalCommitterOperatorTest.java

<li>Added parameterized tests for <code>GlobalCommitterOperator</code>.<br> <li> Enhanced existing tests to cover new commit logic.<br>


</details>


  </td>
  <td><a href="https://github.com/maorethians/flink/pull/1/files#diff-4eb92e02b3ce80a740cc9316af580028e7c51512c991f31f98733bc67552bd60">+99/-44</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>CommittableCollectorTest.java</strong><dd><code>Update CommittableCollectorTest for Optional changes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

flink-runtime/src/test/java/org/apache/flink/streaming/runtime/operators/sink/committables/CommittableCollectorTest.java

- Updated tests to reflect changes in `CommittableCollector`.



</details>


  </td>
  <td><a href="https://github.com/maorethians/flink/pull/1/files#diff-00427b23bfb347cc9ebc3ffeedc68832d2efd30db7f221a05d9dfa39db396330">+7/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information